### PR TITLE
docs: update `ddev get` to `ddev add-on get` in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,14 +39,26 @@ the port number to a free one.
 
 ## Installation
 
-1. In the DDEV project directory launch the command:
-```
-ddev get MurzNN/ddev-grafana
-```
+1. In the DDEV project directory:
+
+  For DDEV v1.23.5 or above run
+
+  ```sh
+  ddev add-on get MurzNN/ddev-grafana
+  ```
+
+  For earlier versions of DDEV run
+
+  ```sh
+  ddev get MurzNN/ddev-grafana
+  ```
+
 2. Restart the DDEV instance:
-```
-ddev restart
-```
+
+  ```sh
+  ddev restart
+  ```
+
 3. Open the Grafana web interface via the url:
    https://your-project-name.ddev.site:3000/
 


### PR DESCRIPTION
In [DDEV 1.23.5](https://github.com/ddev/ddev/releases/tag/v1.23.5) the ddev get command was deprecated in favour of ddev add-on get.

This PR updates those references in the readme file. There may be some additional markdown improvements as well.

The changes were made manually, but the PR itself was automatically created - I'm doing over 100 of these. I apologise if its not 100% to the contributor standards required by this repo. Let me know if I need to change anything.